### PR TITLE
Add support for the input event

### DIFF
--- a/src/rista.js
+++ b/src/rista.js
@@ -12,7 +12,7 @@ let eventTypes = [
 	'dragstart', 'drag', 'dragenter', 'dragleave', 'dragover', 'drop', 'dragend',
 	'keydown', 'keypress', 'keyup',
 	'abort', 'error', 'resize',
-	'select', 'change', 'submit', 'reset',
+	'select', 'change', 'submit', 'reset', 'input',
 	'focusin', 'focusout'
 ];
 


### PR DESCRIPTION
This adds support for the `input` event:

``` javascript
<input type="text" rt-input="onInput">
```

Documentation on [MDN](https://developer.mozilla.org/en-US/docs/Web/Events/input).
